### PR TITLE
Bump to 2.0.0, mapink to 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.6.0
+
+* Updated to mapnik 3.7.0
+
 ## v1.5.0
 
 * Updated to mapnik 3.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
-## v1.6.0
+## v2.0.0
 
 * Updated to mapnik 3.7.0
+* Drops windows support
 
 ## v1.5.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/vector-tile-query",
   "description": "Vector tile query module",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "licenses": [
     {
       "type": "BSD"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/vector-tile-query",
   "description": "Vector tile query module",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "licenses": [
     {
       "type": "BSD"
@@ -23,7 +23,7 @@
   },
   "main": "./index",
   "dependencies": {
-    "mapnik": "~3.6.0",
+    "mapnik": "~3.7.0",
     "queue-async": "1.0.7",
     "@mapbox/sphericalmercator": "~1.0.2"
   },


### PR DESCRIPTION
Bump to `2.0.0`, drops windows support. Updates to `mapnik@3.7.0`